### PR TITLE
Missing Doctrine\Schema use statement

### DIFF
--- a/source/includes/_plugin_install.md
+++ b/source/includes/_plugin_install.md
@@ -6,6 +6,7 @@
 
 namespace MauticPlugin\HelloWorldBundle;
 
+use Doctrine\DBAL\Schema\Schema;
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 use Mautic\PluginBundle\Entity\Plugin;
 use Mautic\CoreBundle\Factory\MauticFactory;


### PR DESCRIPTION
Missing use statement in Install/Upgrade plugin example. 
Causes the runtime notice.