### PR TITLE
Correct and supplement documentation for API send email

### DIFF
--- a/source/includes/_api_endpoint_emails.md
+++ b/source/includes/_api_endpoint_emails.md
@@ -422,6 +422,12 @@ Send a predefined email to existing contact.
 
 `POST /emails/ID/contact/CONTACT_ID/send`
 
+**Post Parameters**
+
+Name|Type|Description
+----|----|-----------
+tokens|array|Array of tokens in email
+
 #### Response
 
 `Expected Response Code: 200`

--- a/source/includes/_api_endpoint_emails.md
+++ b/source/includes/_api_endpoint_emails.md
@@ -420,7 +420,7 @@ Send a predefined email to existing contact.
 
 #### HTTP Request
 
-`POST /emails/ID/send/contact/CONTACT_ID`
+`POST /emails/ID/contact/CONTACT_ID/send`
 
 #### Response
 

--- a/source/includes/_api_endpoint_emails.md
+++ b/source/includes/_api_endpoint_emails.md
@@ -420,7 +420,7 @@ Send a predefined email to existing contact.
 
 #### HTTP Request
 
-`DELETE /emails/ID/send/contact/CONTACT_ID`
+`POST /emails/ID/send/contact/CONTACT_ID`
 
 #### Response
 
@@ -443,7 +443,7 @@ Send a segment email to linked segment(s).
 
 #### HTTP Request
 
-`DELETE /emails/ID/send`
+`POST /emails/ID/send`
 
 #### Response
 


### PR DESCRIPTION
Currently the HTTP Methods for send email are incorrect. 

It also appears the documentation was never updated to change the correct Path for sending an email from the change to the formatting of the API Path. [Made API urls congruent with /$endpoint/$id/$object/$objectId/$action
](https://github.com/mautic/mautic/commit/32d3cd265c7956fd15579b3abb88a3cd2efe5e2a)

There is also an undocumented feature for the "Send Email to Contact" which allows you to specify tokens to be used within the email template. This feature appears to have always been there.