### PR TITLE
Fix wrongly named query parameter

### DIFF
--- a/source/includes/_api_endpoint_campaigns.md
+++ b/source/includes/_api_endpoint_campaigns.md
@@ -190,7 +190,7 @@ start|Starting row for the entities returned. Defaults to 0.
 limit|Limit number of entities to return. Defaults to the system configuration for pagination (30).
 orderBy|Column to sort by. Can use any column listed in the response.
 orderByDir|Sort direction: asc or desc.
-publishedOnly|Only return currently published entities.
+published|Only return currently published entities.
 minimal|Return only array of entities without additional lists in it.
 
 #### Response


### PR DESCRIPTION
To get the list of published campaigns, the documentation says that you should use the following API query https://your.mautic.example/api/campaigns?publishedOnly=1

However looking at the code, it should really be https://your.mautic.example/api/campaigns?published=1

This PR aims to correct this