### PR TITLE
Add plugin settings documentation

### DIFF
--- a/source/includes/_api_endpoint_plugins.md
+++ b/source/includes/_api_endpoint_plugins.md
@@ -1,0 +1,42 @@
+## Plugins
+
+Use this endpoint to manipulate and obtain details on Mautic's plugins.
+
+### Get Plugin Settings
+
+```json
+{
+    "objects": [
+        "lead",
+        "company"
+    ],
+    "update_mautic": {
+        "PrimaryMailAddress": "1",
+        "LastName": "1",
+        "FirstName": "1"
+    },
+    "leadFields": {
+        "PrimaryMailAddress": "email",
+        "LastName": "lastname",
+        "FirstName": "firstname"
+    },
+    "update_mautic_company": {
+        "CompanyName": "1"
+    },
+    "companyFields": {
+        "CompanyName": "companyname"
+    }
+}
+```
+
+Get an individual plugin's configuration
+
+#### HTTP Request
+
+`GET /plugins/settings/INTEGRATION_NAME`
+
+#### Response
+
+`Expected Response Code: 200`
+
+See JSON code example.

--- a/source/index.md
+++ b/source/index.md
@@ -93,6 +93,7 @@ includes:
   - api_endpoint_notes
   - api_endpoint_notifications
   - api_endpoint_pages
+  - api_endpoint_plugins
   - api_endpoint_point_actions
   - api_endpoint_point_triggers
   - api_endpoint_roles


### PR DESCRIPTION
This PR create a new endpoint that allows to get the plugin mapping settings via API. It is very useful for a third application to know how plugins are set.

See https://github.com/mautic/mautic/pull/5306 for more information