### PR TITLE
fix inverted params on add and remove stages of contact

### DIFF
--- a/source/includes/_api_endpoint_stages.md
+++ b/source/includes/_api_endpoint_stages.md
@@ -246,7 +246,7 @@ Same as [Get Stage](#get-stage).
 <?php
 
 //...
-$response = $stageApi->addContact($contactId, $stageId);
+$response = $stageApi->addContact($stageId, $contactId);
 if (!isset($response['success'])) {
     // handle error
 }
@@ -276,7 +276,7 @@ See JSON code example.
 <?php
 
 //...
-$response = $stageApi->removeContact($contactId, $stageId);
+$response = $stageApi->removeContact($stageId, $contactId);
 if (!isset($response['success'])) {
     // handle error
 }


### PR DESCRIPTION
As we see on [code](https://github.com/mautic/api-library/blob/master/lib/Api/Stages.php#L53-L66) and a problem mentioned mautic/api-library#95 contact and stage params is inverted.