### PR TITLE
 Update list contacts api description to reflect the correct orderBy parameters 

### DIFF
--- a/source/includes/_api_endpoint_contacts.md
+++ b/source/includes/_api_endpoint_contacts.md
@@ -246,7 +246,7 @@ Name|Description
 search|String or search command to filter entities by.
 start|Starting row for the entities returned. Defaults to 0.
 limit|Limit number of entities to return. Defaults to the system configuration for pagination (30).
-orderBy|Column to sort by. Can use any column listed in the response. However, all properties in the response that are written in camelCase need to be changed a bit. Before every capital add an underscore `_` and then remove the capital letters. So `dateIdentified` becomes `date_identified`, `modifiedByUser` becomes `modified_by_user` etc.
+orderBy|Column to sort by. Can use any column listed in the response. However, all properties in the response that are written in camelCase need to be changed a bit. Before every capital add an underscore `_` and then change the capital letters to non-capital letters. So `dateIdentified` becomes `date_identified`, `modifiedByUser` becomes `modified_by_user` etc.
 orderByDir|Sort direction: asc or desc.
 publishedOnly|Only return currently published entities.
 minimal|Return only array of entities without additional lists in it.

--- a/source/includes/_api_endpoint_contacts.md
+++ b/source/includes/_api_endpoint_contacts.md
@@ -246,7 +246,7 @@ Name|Description
 search|String or search command to filter entities by.
 start|Starting row for the entities returned. Defaults to 0.
 limit|Limit number of entities to return. Defaults to the system configuration for pagination (30).
-orderBy|Column to sort by. Can use any column listed in the response.
+orderBy|Column to sort by. Can use any column listed in the response. However, all properties in the response that are written in camelCase need to be changed a bit. Before every capital add an underscore `_` and then remove the capital letters. So `dateIdentified` becomes `date_identified`, `modifiedByUser` becomes `modified_by_user` etc.
 orderByDir|Sort direction: asc or desc.
 publishedOnly|Only return currently published entities.
 minimal|Return only array of entities without additional lists in it.


### PR DESCRIPTION
Updated the description of the `orderBy` parameter of the API call for listing contacts. It stated that any column from the response could be used. This was not entirely true as the camelCase colums did not work and need to look like the column looks in the database e.g. `dateIdentified` should be queried as `date_identified` and not  `dateIdentified`.

https://github.com/mautic/mautic/issues/5698
https://github.com/mautic/developer-documentation/issues/94