### PR TITLE
Clarify the edit forms endpoint in regards to form fields

### DIFF
--- a/source/includes/_api_endpoint_forms.md
+++ b/source/includes/_api_endpoint_forms.md
@@ -319,7 +319,12 @@ $data = array(
     'description' => 'API test',
     'fields' => array(
         array(
-            'label' => 'field name',
+            'label' => 'A field that will be added',
+            'type' => 'text'
+        ),
+        array(
+            'id' => 1,
+            'label' => 'A field that will be edited',
             'type' => 'text'
         )
     ),
@@ -342,6 +347,8 @@ $createIfNotFound = true;
 $form = $formApi->edit($id, $data, $createIfNotFound);
 ```
 Edit a new form. Note that this supports PUT or PATCH depending on the desired behavior.
+
+Make sure that whenever you want to edit a form field that you include the form field id in the request. Fields without an id are assumed to be new fields.
 
 **PUT** creates a form if the given ID does not exist and clears all the form information, adds the information from the request. Form fields and actions will be also deleted if not present in the request.
 **PATCH** fails if the form with the given ID does not exist and updates the form field values with the values form the request.


### PR DESCRIPTION
It was never documented that one needs to specify the form field id if one wants to edit a form field. The current documentation makes it look like the field alias is enough, which it isn't. It will result in a new field (and the removal of the old field) which is not the behavior the user expects.