### PR TITLE
start to document database tables

### DIFF
--- a/source/includes/_plugin_database.md
+++ b/source/includes/_plugin_database.md
@@ -254,6 +254,17 @@ When an plugin is installed or updated, the bundle's onInstall or onUpgrade func
 #### Table Prefix
 Mautic allows custom table prefixes.  If using ORM, there is no need to include the prefix as Mautic will automatically handle it.  However, if there is a need to use Doctrine's DBAL layer directly, the contstant `MAUTIC_TABLE_PREFIX` can be used in conjuction with the table name.
 
+#### Description of tables
+
+This is not yet a comprehensive list of all database tables.  Contributions are [very welcome](https://github.com/mautic/developer-documentation/blob/master/CONTRIBUTING.md).
+
+- `leads`: contacts
+- `lead_lists`: segments
+- `lead_lists_leads`: membership of contacts within segments
+- `lead_tags`: tags
+- `lead_tags_xrefs`: associations of tags with contacts
+- `migrations`: tracks which [database migrations](https://github.com/mautic/mautic/tree/staging/app/migrations) have been applied
+
 #### ORM Arrays and DateTime 
 
 When using ORM, Mautic will automatically convert DateTime properties to UTC and to the system/user's profile timezone on retrieval.  However, if using DBAL, DateTime strings must be converted to UTC before persisting and to the local timezone on retrieval.  See [Date/Time Helper](#date/time-helper) to assist with conversions.


### PR DESCRIPTION
Newcomers are at risk of getting confused by the database table names:

- Various parts of Mautic's data model have been renamed (e.g. "leads" to "contacts", "lead lists" to "segments") without changing the names of the underlying database tables.

- Association tables are not named according to a single convention.

And anyway it's generally a good idea to document things explicitly.  So start a list of database tables in the hope that others will help complete it.