### PR TITLE
Improve OAuth2 refresh token documentation

### DIFF
--- a/source/includes/_api_authorization_oauth2.md
+++ b/source/includes/_api_authorization_oauth2.md
@@ -97,7 +97,11 @@ This data should be stored in a secure location and used to authenticate API req
 
 The response's `expires_in` is the number of seconds the access token is good for and may differ based on what is configured in Mautic. The code handling the authorization process should generate an expiration timestamp based on that value. For example `<?php $expiration = time() + $response['expires_in']; ?>`. If the access token has expired, the refresh_token should be used to obtain a new access token.
 
-The refresh token is by default good for 14 days in which the user will need to reauthorize the application with Mautic. However, the refresh token's expiration time is configurable through Mautic's Configuration. 
+By default, the refresh token is valid for 14 days.
+- If your application requests a new access token using the refresh token within 14 days, no user interaction is needed. Your application gets both a new access token and a new refresh token (which is valid for another 14 days after it's issued);
+- If your application does not request a new token using the refresh token within 14 days, user interaction is required in order to get new tokens.
+
+The refresh token's expiration time is configurable through Mautic's Configuration. 
 
 <aside class="notice">
 The application should monitor for a <code>400 Bad Response</code> response when requesting a new access token and redirect the user back through the authorization process.


### PR DESCRIPTION
There was some confusion about the OAuth2 refresh tokens. This PR aims to improve that documentation by adding more explanations.