### PR TITLE
WIP: POST/PUT/PATCH email api translation parent

### DIFF
--- a/source/includes/_api_endpoint_emails.md
+++ b/source/includes/_api_endpoint_emails.md
@@ -368,7 +368,6 @@ customHtml|string|The HTML content of the email
 plainText|string|The plain text content of the email
 template|string|The name of the template used as the base for the email
 emailType|string|If it is a segment (former list) email or template email. Possible values are 'list' and 'template'
-translationChildren|array|Array of Page entities for translations of this landing page
 translationParent|object|The parent/main page if this is a translation
 variantSentCount|int|Sent count since variantStartDate
 variantReadCount|int|Read count since variantStartDate

--- a/source/includes/_api_endpoint_emails.md
+++ b/source/includes/_api_endpoint_emails.md
@@ -295,8 +295,9 @@ customHtml|string|The HTML content of the email
 plainText|string|The plain text content of the email
 template|string|The name of the template used as the base for the email
 emailType|string|If it is a segment (former list) email or template email. Possible values are 'list' and 'template'
-translationChildren|array|Array of Page entities for translations of this landing page
-translationParent|object|The parent/main page if this is a translation
+translationChildren|array|Array of email entities for translations of this email
+templateTranslationParent|object|(Only if emailType is 'template') The parent/main email if this is a translation.
+segmentTranslationParent|object|(Only if emailType is 'list') The parent/main email if this is a translation.
 variantSentCount|int|Sent count since variantStartDate
 variantReadCount|int|Read count since variantStartDate
 variantChildren|array|Array of Email entities for variants of this landing email


### PR DESCRIPTION
I opened this PR for a discussion.
#7064 pointed out that you dont have to specify translationParent but `templateTranslationParent` OR `segmentedTranslationParent` instead. This works on the current 2.16 release fine.

Beside that, `translationChildren` are not evaluated because the backend always calls `$parent->getTranslationChildren()`.

How would i document that different variable name depended on emailType? If i have a "nicer" solution i will create a fresh clean PR.