### PR TITLE
Update extending pages (EventSubscriberInterface)

### DIFF
--- a/source/includes/_plugin_extending_pages.md
+++ b/source/includes/_plugin_extending_pages.md
@@ -6,15 +6,15 @@
 
 namespace MauticPlugin\HelloWorldBundle\EventListener;
 
-use Mautic\CoreBundle\EventListener\CommonSubscriber;
 use Mautic\PageBundle\PageEvents;
 use Mautic\PageBundle\Event\PageBuilderEvent;
 use Mautic\PageBundle\Event\PageSendEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Class PageSubscriber
  */
-class PageSubscriber extends CommonSubscriber
+class PageSubscriber implements EventSubscriberInterface
 {
 
     /**


### PR DESCRIPTION
This is **partly** work for https://github.com/mautic/developer-documentation/issues/159, but it doesn't close the issue yet (there are more examples where the removed `CommonSubscriber` is used). 

This PR fixes one of the cases where `CommonSubscriber` should be removed.