### PR TITLE
Migrated integration framework docs

### DIFF
--- a/source/includes/_api_endpoint_contacts.md
+++ b/source/includes/_api_endpoint_contacts.md
@@ -1002,7 +1002,7 @@ See [Campaigns](#campaigns).
 
 $events = $contactApi->getEvents($id, $search, $includeEvents, $excludeEvents, $orderBy, $orderByDir, $page);
 ```
-Warining: Deprecated. Use `getActivityForContact` instead.
+Warning: Deprecated. Use `getActivityForContact` instead.
 
 ** Query Parameters **
 
@@ -1067,7 +1067,7 @@ Get a list of contact events the contact created.
 
 `GET /contacts/ID/events`
 
-Warining: Deprecated. Use `GET /contacts/ID/activity` instead.
+Warning: Deprecated. Use `GET /contacts/ID/activity` instead.
 
 #### Response
 

--- a/source/includes/_plugin_install.md
+++ b/source/includes/_plugin_install.md
@@ -1,5 +1,7 @@
 ## Install/Upgrade
 
+THIS IS NOW DEPRECATED AND DISCOURAGED FROM USE. USE THE [INTEGRATION FRAMEWORK'S MIGRATION](#plugin_schema) INSTEAD.
+
 ```php
 <?php
 // plugins/HelloWorldBundle/HelloWorldBundle.php

--- a/source/includes/_plugin_integrations.md
+++ b/source/includes/_plugin_integrations.md
@@ -1,0 +1,80 @@
+## Integration Framework
+
+The IntegrationsBundle is meant to be a drop in replacement for Mautic's PluginBundle's AbstractIntegration class. It provides cleaner interfaces for configuring, authenticating and syncing contacts/companies with 3rd party integrations.
+
+An example HelloWorld plugin is available [here](https://github.com/mautic/plugin-helloworld).
+
+### Using the Integration Framework
+
+*If the integration requires authentication with the 3rd party service*
+
+1. [Register the integration](#registering-the-integration-for-authentication) to as an integration that requires configuration options.
+2. Create a custom Symfony form type for the required credentials and return it as part of the [config interface](#mauticpluginintegrationsbundleintegrationinterfacesconfigformauthinterface).
+3. Create a custom service that builds and configures the Guzzle client required to authenticate and communicate with the 3rd party service. Use an [existing supported factory or create a new one](#authentication-providers).
+
+*If the integration has extra configuration settings for features unique to it*
+
+1. [Register the integration](#registering-the-integration-for-configuration) to as an integration that requires configuration options.
+2. Create a custom Symfony form type for the features and return it as part of the [config interface](#mauticpluginintegrationsbundleintegrationinterfacesconfigformfeaturesettingsinterface).
+
+*If the integration syncs with Mautic's contacts and/or companies*
+
+1. Read about [the sync engine](#integration-sync-engine).
+
+### Basics
+Each integration provides its unique name as registered with Mautic, icon, and display name. When an integration is registered, the integration helper classes will manage the `\Mautic\PluginBundle\Entity\Integration` object through `\Mautic\IntegrationsBundle\Integration\Interfaces\IntegrationInterface`. It handles decryption and encryption of the integration's API keys so the implementing code never has to.
+
+##### Registering the Integration
+All integrations whether it uses the config, auth or sync interfaces must have a class that registers itself with Mautic. The integration will be listed no the `/s/plugins` page.
+
+In the plugin's `Config/config.php`, register the integration using the tag `mautic.basic_integration`.
+
+```php
+return [
+    // ...
+    'services' => [
+        // ...
+        'integrations' => [
+            'helloworld.integration' => [
+                'class' => \MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration::class,
+                'tags'  => [
+                    'mautic.basic_integration',
+                ],
+            ],
+            // ...
+        ],
+        // ...
+    ],
+    // ...
+];
+```
+
+The `HelloWorldIntegration` will need to implement `\Mautic\IntegrationsBundle\Integration\Interfaces\IntegrationInterface` and `\Mautic\IntegrationsBundle\Integration\Interfaces\BasicInterface` interfaces. Most use cases can simply extend the `\Mautic\IntegrationsBundle\Integration\BasicIntegration` abstract class then define the `getName()`, `getDisplayName()` and `getIcon()` methods.
+
+```php
+namespace MauticPlugin\HelloWorldBundle\Integration;
+
+use MauticPlugin\IntegrationsBundle\Integration\BasicIntegration;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\BasicInterface;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\IntegrationInterface;
+
+class HelloWorldIntegration extends BasicIntegration
+{
+    const NAME = 'HelloWorld';
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function getDisplayName(): string
+    {
+        return 'Hello World';
+    }
+
+    public function getIcon(): string
+    {
+        return 'plugins/HelloWorldBundle/Assets/img/helloworld.png';
+    }
+}
+```

--- a/source/includes/_plugin_integrations_authentication.md
+++ b/source/includes/_plugin_integrations_authentication.md
@@ -1,0 +1,683 @@
+### Integration Authentication
+The integrations bundle provides factories and helpers to create Guzzle Client classes for common authentication protocols. 
+
+#### Registering the Integration for Authentication
+If the integration requires the user to authenticate through the web (OAuth2 three legged), the integration needs to tag a service with `mautic.auth_integration` to handle the authentication process (redirecting to login, request the access token, etc). This service will need to implement `\Mautic\IntegrationsBundle\Integration\Interfaces\AuthenticationInterface`.
+
+```php
+return [
+    // ...
+    'services' => [
+        // ...
+        'integrations' => [
+            // ...
+            'helloworld.integration.authentication' => [
+                'class' => \MauticPlugin\HelloWorldBundle\Integration\Support\AuthSupport::class,
+                'tags'  => [
+                    'mautic.auth_integration',
+                ],
+            ],
+            // ...
+        ],
+        // ...
+    ],
+    // ...
+];
+```
+
+The `AuthSupport` class must implement `\Mautic\IntegrationsBundle\Integration\Interfaces\AuthenticationInterface`.
+
+```php
+namespace MauticPlugin\HelloWorldBundle\Integration\Support;
+
+use MauticPlugin\HelloWorldBundle\Connection\Client;
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Integration\ConfigurationTrait;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\AuthenticationInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class AuthSupport implements AuthenticationInterface
+{
+    use ConfigurationTrait;
+
+    /**
+     * @var Client
+     */
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function getName(): string
+    {
+        return HelloWorldIntegration::NAME;
+    }
+
+    public function getDisplayName(): string
+    {
+        return 'Hello World';
+    }
+
+    /**
+     * Returns true if the integration has already been authorized with the 3rd party service.
+     *
+     * @return bool
+     */
+    public function isAuthenticated(): bool
+    {
+        $apiKeys = $this->getIntegrationConfiguration()->getApiKeys();
+
+        return !empty($apiKeys['access_token']) && !empty($apiKeys['refresh_token']);
+    }
+
+    /**
+     * Authenticate and obtain the access token
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function authenticateIntegration(Request $request): string
+    {
+        $code = $request->query->get('code');
+
+        $this->client->authenticate($code);
+
+        return 'Success!';
+    }
+}
+```
+
+#### Authentication Providers
+The integrations bundle comes with a number of popular authentication protocols available to use as Guzzle clients. New ones can be created by implementing `\Mautic\IntegrationsBundle\Auth\Provider\AuthProviderInterface.`
+
+**The examples below use anonymous classes. Of course, use OOP with services and factories to generate credential, configuration, and client classes.** The best way to get configuration values such as username, password, consumer key, consumer secret, etc is by using the `mautic.integrations.helper` (`\Mautic\IntegrationsBundle\Helper\IntegrationsHelper`) service in order to leverage the configuration stored in the `Integration` entity's api keys. 
+
+```php
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+$username = $apiKeys['username'] ?? null;
+$password = $apiKeys['password'] ?? null;
+
+//...
+```
+
+##### Api Key
+Use the `mautic.integrations.auth_provider.api_key` service (`\Mautic\IntegrationsBundle\Auth\Provider\ApiKey\HttpFactory`) to obtain a `GuzzleHttp\ClientInterface` that uses an API key for all requests. Out of the box, the factory supports a parameter API key or a header API key.
+
+###### Parameter Based API Key
+
+To use the parameter based API key, create a credentials class that implements `\Mautic\IntegrationsBundle\Auth\Provider\ApiKey\Credentials\ParameterCredentialsInterface`. 
+
+```php
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\ApiKey\Credentials\ParameterCredentialsInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\ApiKey\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$apiKeys = $integration->getIntegrationConfiguration()->getApiKeys();
+
+$credentials = new class($apiKeys['api_key']) implements ParameterCredentialsInterface {
+    private $key;
+
+    public function __construct(string $key)
+    {
+        $this->key = $key;
+    }
+
+    public function getKeyName(): string
+    {
+        return 'apikey';
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->key;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials);
+$response = $client->get('https://api-url.com/fetch');
+```
+
+###### Header Based API Key
+```php
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\ApiKey\Credentials\HeaderCredentialsInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\ApiKey\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$apiKeys = $integration->getIntegrationConfiguration()->getApiKeys();
+
+$credentials = new class($apiKeys['api_key']) implements HeaderCredentialsInterface {
+    private $key;
+
+    public function __construct(string $key)
+    {
+        $this->key = $key;
+    }
+
+    public function getKeyName(): string
+    {
+        return 'X-API-KEY';
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->key;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials);
+$response = $client->get('https://api-url.com/fetch');
+```
+
+##### Basic Auth
+Use the `mautic.integrations.auth_provider.basic_auth` service (`\Mautic\IntegrationsBundle\Auth\Provider\BasicAuth\HttpFactory`) to obtain a `GuzzleHttp\ClientInterface` that uses basic auth for all requests.
+
+```php
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\BasicAuth\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\BasicAuth\CredentialsInterface;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+$credentials = new class($apiKeys['username'], $apiKeys['password']) implements CredentialsInterface {
+    private $username;
+    private $password;
+
+    public function __construct(string $username, string $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials);
+$response = $client->get('https://api-url.com/fetch');
+```
+
+##### OAuth1a
+###### OAuth1a Three Legged 
+
+This has not been implemented yet.
+
+###### OAuth1a Two Legged
+OAuth1A two legged does not require a user to login as would three legged. 
+
+```php
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\OAuth1aTwoLegged\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\OAuth1aTwoLegged\CredentialsInterface;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+$credentials = new class(
+    'https://api-url.com/oauth/token', 
+    $apiKeys['consumer_key'], 
+    $apiKeys['consumer_secret']
+) implements CredentialsInterface {
+    private $authUrl;
+    private $consumerKey;
+    private $consumerSecret;
+
+    public function __construct(string $authUrl, string $consumerKey, string $consumerSecret)
+    {
+        $this->authUrl        = $authUrl;
+        $this->consumerKey    = $consumerKey;
+        $this->consumerSecret = $consumerSecret;
+    }
+
+    public function getAuthUrl(): string
+    {
+        return $this->authUrl;
+    }
+
+    public function getConsumerKey(): ?string
+    {
+        return $this->consumerKey;
+    }
+
+    public function getConsumerSecret(): ?string
+    {
+        return $this->consumerSecret;
+    }
+
+    /**
+     * Not used in this example. Tsk tsk for breaking the interface segregation principle
+     *
+     * @return string|null
+     */
+    public function getToken(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Not used in this example. Tsk tsk for breaking the interface segregation principle
+     *
+     * @return string|null
+     */
+    public function getTokenSecret(): ?string
+    {
+        return null;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials);
+$response = $client->get('https://api-url.com/fetch');
+```
+##### OAuth2
+Use the OAuth2 factory according to the grant type required. `\Mautic\IntegrationsBundle\Auth\Provider\Oauth2ThreeLegged\HttpFactory` supports `code` and `refresh_token` grant types. `\Mautic\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\HttpFactory` supports `client_credentials` and `password`.
+
+The OAuth2 factories leverages [https://github.com/kamermans/guzzle-oauth2-subscriber] as a middleware.
+
+###### Client Configuration
+Both OAuth2 factories leverage `\Mautic\IntegrationsBundle\Auth\Provider\AuthConfigInterface` object to configure things such as configuring the signer (basic auth, post form data, custom), token factory, token persistence, and token signer (bearer auth, basic auth, query string, custom). Use the appropriate interfaces as required for the use case (see the interfaces in `plugins/IntegrationsBundle/Auth/Support/Oauth2/ConfigAccess`). 
+
+See [https://github.com/kamermans/guzzle-oauth2-subscriber] for additional details on configuring the credentials and token signers or creating custom token persistence and factories. 
+
+###### Integration Token Persistence
+For most use cases, a token persistence service to fetch and store the access tokens generated by using refresh tokens, etc will be required. The integrations bundle provides one that natively uses the `\Mautic\PluginBundle\Entity\Integration` entity's api keys. Anything stored through the service is automatically encrypted. 
+
+Use the `mautic.integrations.auth_provider.token_persistence_factory` service (`\Mautic\IntegrationsBundle\Auth\Support\Oauth2\Token\TokenPersistenceFactory`) to generate a `TokenFactoryInterface` to be returned by the `\Mautic\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenFactoryInterface` interface. 
+ 
+```php
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenPersistenceInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\Token\TokenPersistenceFactory;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+/** @var $tokenPersistenceFactory TokenPersistenceFactory */
+$tokenPersistence = $tokenPersistenceFactory->create($integration);
+
+$config = new class($tokenPersistence) implements ConfigTokenPersistenceInterface {
+    private $tokenPersistence;
+
+    public function __construct(TokenPersistenceInterface$tokenPersistence)
+    {
+        $this->tokenPersistence = $tokenPersistence;
+    }
+
+    public function getTokenPersistence(): TokenPersistenceInterface
+    {
+        return $this->tokenPersistence;
+    }
+};
+```
+
+The token persistence service will automatically manage `access_token`, `refresh_token`, and `expires_at` from the authentication process which are stored in the `Integration` entity's api keys array.
+
+###### Token Factory
+In some cases, the 3rd party service may return additional values that are not traditionally part of the oauth2 spec and these values are required for further communication with the api service. In this case, the integration bundle's `\Mautic\IntegrationsBundle\Auth\Support\Oauth2\Token\IntegrationTokenFactory` can be used to capture those extra values and store them in the `Integration` entity's api keys array. 
+
+The `IntegrationTokenFactory` can then be returned in a `\Mautic\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenFactoryInterface` when configuring the `Client`. 
+
+```php
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenFactoryInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\Token\IntegrationTokenFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\Token\TokenFactoryInterface;
+
+$tokenFactory = new IntegrationTokenFactory(['something_extra']);
+
+$config = new class($tokenFactory) implements ConfigTokenFactoryInterface {
+    private $tokenFactory;
+
+    public function __construct(TokenFactoryInterface $tokenFactory)
+    {
+        $this->tokenFactory = $tokenFactory;
+    }
+
+    public function getTokenFactory(): TokenFactoryInterface
+    {
+        return $this->tokenFactory;
+    }
+};
+```
+
+##### OAuth2 Two Legged
+
+###### Password Grant
+Below is an example of the password grant for a service that uses a scope (optional interface). The use of the token persistence is assuming the access token is valid for a period of time (i.e. an hour). 
+
+```php
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\Credentials\PasswordCredentialsGrantInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\Credentials\ScopeInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenPersistenceInterface;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+$credentials = new class(
+    'https://api-url.com/oauth/token',
+    'scope1,scope2',
+    $apiKeys['client_id'],
+    $apiKeys['client_secret'],
+    $apiKeys['username'],
+    $apiKeys['password']
+) implements PasswordCredentialsGrantInterface, ScopeInterface {
+    private $authorizeUrl;
+    private $scope;
+    private $clientId;
+    private $clientSecret;
+    private $username;
+    private $password;
+
+    public function getAuthorizationUrl(): string
+    {
+        return $this->authorizeUrl;
+    }
+
+    public function getClientId(): ?string
+    {
+        return $this->clientId;
+    }
+
+    public function getClientSecret(): ?string
+    {
+        return $this->clientSecret;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    public function getScope(): ?string
+    {
+        return $this->scope;
+    }
+};
+
+/** @var $tokenPersistenceFactory TokenPersistenceFactory */
+$tokenPersistence = $tokenPersistenceFactory->create($integration);
+$config           = new class($tokenPersistence) implements ConfigTokenPersistenceInterface {
+    private $tokenPersistence;
+
+    public function __construct(TokenPersistenceInterface$tokenPersistence)
+    {
+        $this->tokenPersistence = $tokenPersistence;
+    }
+
+    public function getTokenPersistence(): TokenPersistenceInterface
+    {
+        return $this->tokenPersistence;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials, $config);
+$response = $client->get('https://api-url.com/fetch');
+```
+
+###### Client Credentials Grant
+Below is an example of the client credentials grant for a service that uses a scope (optional interface). The use of the token persistence is assuming the access token is valid for a period of time (i.e. an hour). 
+
+```php
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\Credentials\ClientCredentialsGrantInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\Credentials\ScopeInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenPersistenceInterface;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+$credentials = new class(
+    'https://api-url.com/oauth/token',
+    'scope1,scope2',
+    $apiKeys['client_id'],
+    $apiKeys['client_secret']
+) implements ClientCredentialsGrantInterface, ScopeInterface {
+    private $authorizeUrl;
+    private $scope;
+    private $clientId;
+    private $clientSecret;
+
+    public function getAuthorizationUrl(): string
+    {
+        return $this->authorizeUrl;
+    }
+
+    public function getClientId(): ?string
+    {
+        return $this->clientId;
+    }
+
+    public function getClientSecret(): ?string
+    {
+        return $this->clientSecret;
+    }
+    
+    public function getScope(): ?string
+    {
+        return $this->scope;
+    }
+};
+
+/** @var $tokenPersistenceFactory TokenPersistenceFactory */
+$tokenPersistence = $tokenPersistenceFactory->create($integration);
+$config           = new class($tokenPersistence) implements ConfigTokenPersistenceInterface {
+    private $tokenPersistence;
+
+    public function __construct(TokenPersistenceInterface$tokenPersistence)
+    {
+        $this->tokenPersistence = $tokenPersistence;
+    }
+
+    public function getTokenPersistence(): TokenPersistenceInterface
+    {
+        return $this->tokenPersistence;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials, $config);
+$response = $client->get('https://api-url.com/fetch');
+```
+
+##### OAuth2 Three Legged
+Three legged OAuth2 with the code grant is the most complex to implement because it involves redirecting the user to the 3rd party service to authenticate then sent back to Mautic to initiate the access token process using a code returned in the request. 
+
+The first step is to register the integration as a [`\Mautic\IntegrationsBundle\Integration\Interfaces\AuthenticationInterface`](#registering-the-integration-for-authentication). The `authenticateIntegration()` method will be used to initiate the access token process using the `code` returned in the request after the user logs into the 3rd party service. The integrations bundle provides a route that can be used as the redirect or callback URIs through the named route `mautic_integration_public_callback` that requires a `integration` parameter. This redirect URI can be displayed in the UI by using [`ConfigFormCallbackInterface`](https://github.com/mautic/plugin-integrations/wiki/2.-Integration-Configuration#mauticpluginintegrationsbundleintegrationinterfacesconfigformcallbackinterface). This route will find the integration by name from the `AuthIntegrationsHelper` then execute its `authenticateIntegration()`. 
+
+```php
+namespace MauticPlugin\HelloWorldBundle\Integration\Support;
+
+use GuzzleHttp\ClientInterface;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\AuthenticationInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthSupport implements AuthenticationInterface {
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+    
+    // ...
+    
+    public function authenticateIntegration(Request $request): Response
+    {
+        $code = $request->query->get('code');
+
+        $this->client->authenticate($code);
+
+        return new Response('OK!');
+    }
+}
+```
+
+The trick here is that the `Client`'s `authenticate` method will configure a `ClientInterface` then make a call to any valid API url (*this is required*). By making a call, the middleware will initiate the access token process and store it in the `Integration` entity's api keys through the [`TokenPersistenceFactory`](#integration-token-persistence). The URL is recommended to be something simple like a version check or fetching info for the authenticated user.
+
+Here is an example of a client, assuming that the user has already logged in and the code is in the request.
+
+```php
+use kamermans\OAuth2\Persistence\TokenPersistenceInterface;
+use MauticPlugin\HelloWorldBundle\Integration\HelloWorldIntegration;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2ThreeLegged\Credentials\CodeInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2ThreeLegged\Credentials\CredentialsInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2ThreeLegged\Credentials\RedirectUriInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\Credentials\ScopeInterface;
+use MauticPlugin\IntegrationsBundle\Auth\Provider\Oauth2TwoLegged\HttpFactory;
+use MauticPlugin\IntegrationsBundle\Auth\Support\Oauth2\ConfigAccess\ConfigTokenPersistenceInterface;
+use MauticPlugin\IntegrationsBundle\Helper\IntegrationsHelper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Router;
+
+/** @var $integrationsHelper IntegrationsHelper */
+$integration = $integrationsHelper->getIntegration(HelloWorldIntegration::NAME);
+
+/** @var Router $router */
+$redirectUrl = $router->generate('mautic_integration_public_callback', ['integration' => HelloWorldIntegration::NAME]);
+
+$configuration = $integration->getIntegrationConfiguration();
+$apiKeys       = $configuration->getApiKeys();
+
+/** @var Request $request */
+$code = $request->get('code');
+
+$credentials = new class(
+    'https://api-url.com/oauth/authorize',
+    'https://api-url.com/oauth/token',
+    $redirectUrl,
+    'scope1,scope2',
+    $apiKeys['client_id'],
+    $apiKeys['client_secret'],
+    $code
+) implements CredentialsInterface, RedirectUriInterface, ScopeInterface, CodeInterface {
+    private $authorizeUrl;
+    private $tokenUrl;
+    private $redirectUrl;
+    private $scope;
+    private $clientId;
+    private $clientSecret;
+    private $code;
+
+    public function __construct(string $authorizeUrl, string $tokenUrl, string $redirectUrl, string $scope, string $clientId, string $clientSecret, ?string $code)
+    {
+        $this->authorizeUrl = $authorizeUrl;
+        $this->tokenUrl     = $tokenUrl;
+        $this->redirectUrl  = $redirectUrl;
+        $this->scope        = $scope;
+        $this->clientId     = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->code         = $code;
+    }
+
+    public function getAuthorizationUrl(): string
+    {
+        return $this->authorizeUrl;
+    }
+
+    public function getTokenUrl(): string
+    {
+        return $this->tokenUrl;
+    }
+
+    public function getRedirectUri(): string
+    {
+        return $this->redirectUrl;
+    }
+
+    public function getClientId(): ?string
+    {
+        return $this->clientId;
+    }
+
+    public function getClientSecret(): ?string
+    {
+        return $this->clientSecret;
+    }
+
+    public function getScope(): ?string
+    {
+        return $this->scope;
+    }
+    
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+};
+
+/** @var $tokenPersistenceFactory TokenPersistenceFactory */
+$tokenPersistence = $tokenPersistenceFactory->create($integration);
+$config           = new class($tokenPersistence) implements ConfigTokenPersistenceInterface {
+    private $tokenPersistence;
+
+    public function __construct(TokenPersistenceInterface$tokenPersistence)
+    {
+        $this->tokenPersistence = $tokenPersistence;
+    }
+
+    public function getTokenPersistence(): TokenPersistenceInterface
+    {
+        return $this->tokenPersistence;
+    }
+};
+
+/** @var $factory HttpFactory */
+$client   = $factory->getClient($credentials, $config);
+$response = $client->get('https://api-url.com/fetch');
+```

--- a/source/includes/_plugin_integrations_configuration.md
+++ b/source/includes/_plugin_integrations_configuration.md
@@ -1,0 +1,96 @@
+### Integration Configuration
+The integration plugin provides interfaces to display and store configuration options that can be accessed through the `\Mautic\PluginBundle\Entity\Integration` object. 
+
+#### Registering the Integration for Configuration
+To tell the IntegrationsBundle that this integration has configuration options, tag the integration or support class with `mautic.config_integration` in the plugin's `app/config.php`.
+
+```php
+return [
+    // ...
+    'services' => [
+        // ...
+        'integrations' => [
+            // ...
+            'helloworld.integration.configuration' => [
+                'class' => \MauticPlugin\HelloWorldBundle\Integration\Support\ConfigSupport::class,
+                'tags'  => [
+                    'mautic.config_integration',
+                ],
+            ],
+            // ...
+        ],
+        // ...
+    ],
+    // ...
+];
+```
+
+The `ConfigSupport` class must implement `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface`.
+
+```php
+namespace MauticPlugin\HelloBundle\Integration\Support;
+
+use MauticPlugin\HelloWorldBundle\Form\Type\ConfigAuthType;
+use MauticPlugin\IntegrationsBundle\Integration\DefaultConfigFormTrait;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface;
+use MauticPlugin\IntegrationsBundle\Integration\Interfaces\ConfigFormAuthInterface;
+
+class ConfigSupport implements ConfigFormInterface, ConfigFormAuthInterface
+{
+    use DefaultConfigFormTrait;
+
+    public function getDisplayName(): string
+    {
+        return 'Hello World';
+    }
+
+    /**
+     * Return a custom Symfony form field type class that will be used on the Enabled/Auth tab.
+     * This should include things like API credentials, URLs, etc. All values from this form fields
+     * will be encrypted before being persisted.
+     *
+     * @link https://symfony.com/doc/2.8/form/create_custom_field_type.html#defining-the-field-type
+     *
+     * @return string
+     */
+    public function getAuthConfigFormName(): string
+    {
+        return ConfigAuthType::class;
+    }
+}
+```
+
+#### Interfaces
+There are multiple interfaces that can be used to add form fields options to the provided configuration tabs. 
+
+##### Enabled/Auth Tab
+These interfaces provide the configuration options for authenticating with the 3rd party service. Read more about how to use integrations bundle's [auth providers here](#integration-authentication).
+
+###### `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormAuthInterface`
+Used in the example above. This interface provides the Symfony form type class that defines the fields to be stored as the api keys. 
+
+```php
+$apiKeys  = $integrationHelper->get(HelloWorldIntegration::NAME)->getIntegrationConfiguration()->getApiKeys();
+$username = $apiKeys['username'];
+```
+
+##### `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormCallbackInterface`
+If the integration leverages an auth provider that requires a callback URL or something similar, this interface provides a means to return a translation string to display in the UI. For example, OAuth2 requires a redirect URI. If the admin has to configure the OAuth credentials in the 3rd party service and needs to know what URL to use in Mautic as the return URI, or callback URL, use the `getCallbackHelpMessageTranslationKey()` method. 
+
+#### Feature Interfaces
+
+##### `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormFeatureSettingsInterface`
+This interface provides the Symfony form type class that defines the fields to be displayed on the Features tab. These values are not encrypted.
+
+```php
+$featureSettings  = $integrationHelper->get(HelloWorldIntegration::NAME)->getIntegrationConfiguration()->getFeatureSettings();
+$doSomething      = $featureSettings['doSomething'];
+```
+
+#### `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormFeaturesInterface`
+Currently the integrations bundle provides default features. To use these features, implement this interface. `getSupportedFeatures` will return an array of supported features. For example, if the integration syncs with Mautic contacts, `getSupportedFeatures()` could `return [ConfigFormFeaturesInterface::FEATURE_SYNC];`.
+
+##### Contact/Company Syncing Interfaces
+The integrations bundle provides a sync framework for 3rd party services to sync with Mautic's contacts and companies. The `\Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface` determines the configuration options for this sync feature. Refer to the method docblocks in the interface for more details. 
+
+Read more about how to leverage the [sync framework](#integration-sync-engine).

--- a/source/includes/_plugin_integrations_migrations.md
+++ b/source/includes/_plugin_integrations_migrations.md
@@ -1,0 +1,58 @@
+### Plugin Schema
+
+The integration framework provides a means for plugins to better manage their schema. Queries are in migration files that match the plugin's versions number in it's config. When the a plugin is installed or upgraded, it will loop over the migration files up to the latest version.
+
+#### AbstractPluginBundle
+
+The plugin's root bundle class should extend `MauticPlugin\IntegrationsBundle\Bundle\AbstractPluginBundle`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\HelloWorldBundle;
+
+use MauticPlugin\IntegrationsBundle\Bundle\AbstractPluginBundle;
+
+class HelloWorldBundle extends AbstractPluginBundle
+{
+}
+
+#### Plugin Migrations
+Each migration file should be stored in the plugin's `Migration` folder with a name that matches `Version_X_Y_Z.php` where `X_Y_Z` matches the semantic versioning of the plugin. Each file should contain the incremental schema changes for the plugin up to the latest version which should match the version in the plugin's Config/config.php file.
+
+There are two methods. `isApplicable` should return true/false if the migration should be ran. `up` should register the SQL to execute.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\HelloWorldBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Mautic\IntegrationsBundle\Migration\AbstractMigration;
+
+class Version_1_0_1 extends AbstractMigration
+{
+    private $table = 'hello_world';
+
+    protected function isApplicable(Schema $schema): bool
+    {
+        try {
+            return !$schema->getTable($this->concatPrefix($this->table))->hasColumn('is_enabled');
+        } catch (SchemaException $e) {
+            return false;
+        }
+    }
+
+    protected function up(): void
+    {
+        $this->addSql("ALTER TABLE `{$this->concatPrefix($this->table)}` ADD `is_enabled` tinyint(1) 0");
+
+        $this->addSql("CREATE INDEX {$this->concatPrefix('is_enabled')} ON {$this->concatPrefix($this->table)}(is_enabled);");
+    }
+}
+```

--- a/source/includes/_plugin_integrations_sync.md
+++ b/source/includes/_plugin_integrations_sync.md
@@ -1,0 +1,58 @@
+### Integration Sync Engine
+The sync engine supports bidirectional syncing between Mautic's contact and companies with 3rd party objects. The engine generates a "sync report" from Mautic that it converts to a "sync order" for the integration to process. It then asks for a "sync report" from the integration which it converts to a "sync order" for Mautic to process. 
+
+When building the report, Mautic or the integration will fetch the objects that have been modified or created within the specified timeframe. If the integration supports changes at the field level, it should tell the report on a per field basis when the field was last updated. Otherwise, it should tell the report when the object itself was last modified. These dates are used by the "sync judge" to determine which value should be used in a bi-directional sync.
+
+The sync is initiated using the `mautic:integrations:sync` command. For example:
+`php app/console mautic:integrations:sync HelloWorld --start-datetime="2020-01-01 00:00:00" --end-datetime="2020-01-02 00:00:00"`. (Use `php bin/console` for Mautic 3). 
+
+#### Registering the Integration for the Sync Engine
+To tell the IntegrationsBundle that this integration has configuration options, tag the integration or support class with `mautic.config_integration` in the plugin's `app/config.php`.
+
+```php
+return [
+    // ...
+    'services' => [
+        // ...
+        'integrations' => [
+            // ...
+            'helloworld.integration.sync' => [
+                'class' => \MauticPlugin\HelloWorldBundle\Integration\Support\SyncSupport::class,
+                'tags'  => [
+                    'mautic.sync_integration',
+                ],
+            ],
+            // ...
+        ],
+        // ...
+    ],
+    // ...
+];
+```
+
+The `SyncSupport` class must implement `\Mautic\IntegrationsBundle\Integration\Interfaces\SyncSupport`.
+
+
+#### Syncing
+
+##### The Mapping Manual
+The mapping manual tells the sync engine which integration should be synced with which Mautic object (contact or company), the integration fields that were mapped to Mautic fields, and the direction the data is supposed to flow. 
+
+See [https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/Mapping/Manual/MappingManualFactory.php]( https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/Mapping/Manual/MappingManualFactory.php)
+
+##### The Sync Data Exchange
+This is where the sync takes place and is executed by the `mautic:integrations:sync` command. Mautic and the integration will build their respective reports of new or modified objects then execute the order from the other side. 
+
+See [https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/SyncDataExchange.php](https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/SyncDataExchange.php)
+
+###### Building Sync Report
+The sync report tells the sync engine what objects are new and/or modified between the two timestamps given by the engine (or up to the integration discretion if it is a first time sync). Objects should be processed in batches which can be done using the `RequestDAO::getSyncIteration()`. The sync engine will execute `SyncDataExchangeInterface::getSyncReport()` until a report comes back with no objects.
+
+If the integration supports field level change tracking, it should tell the report so that the sync engine can merge the two data sets more accurately. 
+
+See [https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/ReportBuilder.php](https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/ReportBuilder.php)
+
+###### Executing the Sync Order
+The sync order contains all the changes the sync engine has determined should be written to the integration. The integration should communicate back the ID of any objects created or adjust objects as needed such as if they were converted from one to another or deleted.
+
+See [https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/OrderExecutioner.php](https://github.com/mautic/plugin-helloworld/blob/mautic-2/Sync/DataExchange/OrderExecutioner.php)

--- a/source/includes/_plugin_migrations_3.0.md
+++ b/source/includes/_plugin_migrations_3.0.md
@@ -1,0 +1,2 @@
+### 3.0.0
+See [UPGRADE-3.0.md](https://github.com/mautic/mautic/blob/features/UPGRADE-3.0.md) 

--- a/source/index.md
+++ b/source/index.md
@@ -16,6 +16,7 @@ includes:
   - plugin_migrations
   - plugin_migrations_1.2
   - plugin_migrations_2.0
+  - plugin_migrations_3.0
   - plugin_structure
   - plugin_install
   - plugin_config
@@ -44,6 +45,11 @@ includes:
   - plugin_database
   - plugin_permissions
   - plugin_configuration
+  - plugin_integrations
+  - plugin_integrations_migrations
+  - plugin_integrations_authentication
+  - plugin_integrations_configuration
+  - plugin_integrations_sync
   - plugin_manipulating_contacts
   - plugin_extending_intro
   - plugin_extending_api


### PR DESCRIPTION
This migrates the integration framework docs from the now removed mautic-inc/plugin-integrations plugin wiki as the code was added to 3.0 core. 