### PR TITLE
Add focus item to push to new docs

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -136,5 +136,6 @@ under the License.
         <% end %>
       </div>
     </div>
+<script src="//m.mautic.org/focus/10.js" type="text/javascript" charset="utf-8" async="async"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR adds a focus item to the old dev docs, advising that it's legacy and pushing people to the new docs.

![screenshot-m mautic org-2024 01 09-21_18_46](https://github.com/mautic/developer-documentation/assets/2930593/548aa729-5549-4d7f-8bc1-6c4943cfda33)

